### PR TITLE
Tg  fewer api calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+data/

--- a/src/CommonComponents/Buttons/DeleteButton.js
+++ b/src/CommonComponents/Buttons/DeleteButton.js
@@ -1,22 +1,42 @@
 import React from "react";
+import { useHistory } from "react-router-dom";
+import { deleteCard, deleteDeck, listDecks } from "../../utils/api";
 
-function DeleteButton({ objToDelete, objType }) {
+function DeleteButton({ objToDelete, objType, setDecks }) {
+  const history = useHistory();
   //Event Handler to Delete specefied object
   function handleDelete() {
     if (
       window.confirm(
         `Delete this ${objType}?\n\nYou will not be able to recover it.`
       )
-    )
-      console.log(`Attempting to delete: `, objToDelete);
-      //make the delete request
-      //make a get request
-      //call setDecks passed in as a property setting to the new get call
-      //history.push("")
+    ) {
+      //Distinguish the type of delete
+      objType === "deck"
+        ? deleteDeck(objToDelete.id).then(updateDecks) //deleteDeck if it's a Deck
+        : deleteCard(objToDelete.id).then(updateDecks); //deleteCard if it's a Card
+    }
+    //if we cancel, then go home without deleting
+    else history.push("");
   }
+
+  function updateDecks() {
+    const controller = new AbortController(); //to abort old requests
+    listDecks(controller.signal)
+      .then(setDecks)
+      .catch((error) => {
+        if (error.name !== "AbortError") throw error;
+      });
+    // .then(() => history.push(""));
+  }
+
   return (
     <button className="btn btn-danger mx-1" onClick={() => handleDelete()}>
-      <span className="oi oi-trash pr-2" title="trash" aria-hidden="true"></span>
+      <span
+        className="oi oi-trash pr-2"
+        title="trash"
+        aria-hidden="true"
+      ></span>
       Delete
     </button>
   );

--- a/src/CommonComponents/Buttons/DeleteButton.js
+++ b/src/CommonComponents/Buttons/DeleteButton.js
@@ -9,6 +9,10 @@ function DeleteButton({ objToDelete, objType }) {
       )
     )
       console.log(`Attempting to delete: `, objToDelete);
+      //make the delete request
+      //make a get request
+      //call setDecks passed in as a property setting to the new get call
+      //history.push("")
   }
   return (
     <button className="btn btn-danger mx-1" onClick={() => handleDelete()}>

--- a/src/Decks/Deck/CardList.js
+++ b/src/Decks/Deck/CardList.js
@@ -3,7 +3,7 @@ import CardListItem from "./CardListItem";
 
 function CardList({ cards, setCards }) {
   //map through every card in cards to create a CardListItem for each.
-  const cardList = cards.map((card, key) => (
+  const cardList = cards?.map((card, key) => (
     <CardListItem key={key} card={card} setCards={setCards} />
   ));
 

--- a/src/Decks/Deck/CardList.js
+++ b/src/Decks/Deck/CardList.js
@@ -1,10 +1,10 @@
 import React from "react";
 import CardListItem from "./CardListItem";
 
-function CardList({ cards, setCards }) {
+function CardList({ cards }) {
   //map through every card in cards to create a CardListItem for each.
   const cardList = cards?.map((card, key) => (
-    <CardListItem key={key} card={card} setCards={setCards} />
+    <CardListItem key={key} card={card} />
   ));
 
   return <>{cardList}</>;

--- a/src/Decks/Deck/CardList.js
+++ b/src/Decks/Deck/CardList.js
@@ -1,12 +1,15 @@
 import React, { useEffect, useState } from "react";
 import CardListItem from "./CardListItem";
 
-function CardList({ cards, setDecks }) {
+function CardList({ cards, setCards }) {
   //map through every card in cards to create a CardListItem for each.
+
   const [cardList, setCardList] = useState([]);
   useEffect(() => {
     setCardList(
-      cards?.map((card, key) => <CardListItem key={key} card={card} setDecks={setDecks} />)
+      cards?.map((card, key) => (
+        <CardListItem key={key} card={card} setCards={setCards} />
+      ))
     );
   }, [cards]);
 

--- a/src/Decks/Deck/CardList.js
+++ b/src/Decks/Deck/CardList.js
@@ -2,17 +2,20 @@ import React, { useEffect, useState } from "react";
 import CardListItem from "./CardListItem";
 
 function CardList({ cards, setCards }) {
-  //map through every card in cards to create a CardListItem for each.
-
+  //useState variable to store an array of CardListItem components
   const [cardList, setCardList] = useState([]);
+
+  //Update cardList whenever there is a change to cards or setCards
   useEffect(() => {
+    //map through every card in cards to create a CardListItem for each.
     setCardList(
       cards?.map((card, key) => (
         <CardListItem key={key} card={card} setCards={setCards} />
       ))
     );
-  }, [cards]);
+  }, [cards, setCards]);
 
+  //Parent component DeckView is handling the LoadingMessage, so just return the list
   return <>{cardList}</>;
 }
 

--- a/src/Decks/Deck/CardList.js
+++ b/src/Decks/Deck/CardList.js
@@ -1,11 +1,14 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import CardListItem from "./CardListItem";
 
-function CardList({ cards }) {
+function CardList({ cards, setDecks }) {
   //map through every card in cards to create a CardListItem for each.
-  const cardList = cards?.map((card, key) => (
-    <CardListItem key={key} card={card} />
-  ));
+  const [cardList, setCardList] = useState([]);
+  useEffect(() => {
+    setCardList(
+      cards?.map((card, key) => <CardListItem key={key} card={card} setDecks={setDecks} />)
+    );
+  }, [cards]);
 
   return <>{cardList}</>;
 }

--- a/src/Decks/Deck/CardListItem.js
+++ b/src/Decks/Deck/CardListItem.js
@@ -3,8 +3,9 @@ import { useRouteMatch } from "react-router-dom";
 import DeleteButton from "../../CommonComponents/Buttons/DeleteButton";
 import EditButton from "../../CommonComponents/Buttons/EditButton";
 
+//CardListItem is a template that makes an HTML Card with the correct data to be be displayed
 function CardListItem({ card, setCards }) {
-  const { url } = useRouteMatch();
+  const { url } = useRouteMatch(); //Grab the url for the EditButton's path
   return (
     <div className="card">
       <div className="card-body">

--- a/src/Decks/Deck/CardListItem.js
+++ b/src/Decks/Deck/CardListItem.js
@@ -3,7 +3,7 @@ import { useRouteMatch } from "react-router-dom";
 import DeleteButton from "../../CommonComponents/Buttons/DeleteButton";
 import EditButton from "../../CommonComponents/Buttons/EditButton";
 
-function CardListItem({ card }) {
+function CardListItem({ card, setCards }) {
   const { url } = useRouteMatch();
   return (
     <div className="card">
@@ -11,7 +11,11 @@ function CardListItem({ card }) {
         <p className="card-text">{card.front}</p>
         <p className="card-text">{card.back}</p>
         <EditButton path={`${url}/cards/${card.id}`} />
-        <DeleteButton objToDelete={card} objType={"card"} />
+        <DeleteButton
+          objToDelete={card}
+          objType={"card"}
+          setObjState={setCards}
+        />
       </div>
     </div>
   );

--- a/src/Decks/Deck/DeckView.js
+++ b/src/Decks/Deck/DeckView.js
@@ -9,8 +9,12 @@ import LoadingMessage from "../../CommonComponents/LoadingMessage";
 import CardList from "./CardList";
 
 function DeckView({ deck, setDeck }) {
-  const { url } = useRouteMatch();
+  const { url } = useRouteMatch(); //Grab the url for the for each button's path
+
+  //cards is a state variable array of each card in the current deck
   const [cards, setCards] = useState([]);
+
+  //Update cards array whenever there is a change to it's parent Component's deck Object
   useEffect(() => {
     setCards(deck?.cards);
   }, [deck]);

--- a/src/Decks/Deck/DeckView.js
+++ b/src/Decks/Deck/DeckView.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useRouteMatch } from "react-router-dom";
 import AddCardButton from "../../CommonComponents/Buttons/AddCardButton";
 import DeleteButton from "../../CommonComponents/Buttons/DeleteButton";
@@ -8,9 +8,14 @@ import Breadcrumb from "../../CommonComponents/Breadcrumb";
 import LoadingMessage from "../../CommonComponents/LoadingMessage";
 import CardList from "./CardList";
 
-function DeckView({ deck }) {
+function DeckView({ deck, setDeck }) {
   const { url } = useRouteMatch();
-  return deck?.cards ? (
+  const [cards, setCards] = useState([]);
+  useEffect(() => {
+    setCards(deck?.cards);
+  }, [deck]);
+
+  return deck?.name && cards ? (
     <>
       <Breadcrumb navTitles={[deck.name]} />
       <h2>{deck.name}</h2>
@@ -18,10 +23,14 @@ function DeckView({ deck }) {
         <EditButton path={url} />
         <StudyButton path={url} />
         <AddCardButton path={url} />
-        <DeleteButton objToDelete={deck} objType={"deck"} />
+        <DeleteButton
+          objToDelete={deck}
+          objType={"deck"}
+          setObjState={setDeck}
+        />
       </div>
       <h2>Cards</h2>
-      <CardList cards={deck.cards} />
+      <CardList cards={cards} setCards={setCards} />
     </>
   ) : (
     <LoadingMessage />

--- a/src/Decks/Deck/DeckView.js
+++ b/src/Decks/Deck/DeckView.js
@@ -8,7 +8,7 @@ import Breadcrumb from "../../CommonComponents/Breadcrumb";
 import LoadingMessage from "../../CommonComponents/LoadingMessage";
 import CardList from "./CardList";
 
-function DeckView({ deck, setCards }) {
+function DeckView({ deck }) {
   const { url } = useRouteMatch();
   return deck?.cards ? (
     <>
@@ -21,7 +21,7 @@ function DeckView({ deck, setCards }) {
         <DeleteButton objToDelete={deck} objType={"deck"} />
       </div>
       <h2>Cards</h2>
-      <CardList cards={deck.cards} setCards={setCards} />
+      <CardList cards={deck.cards} />
     </>
   ) : (
     <LoadingMessage />

--- a/src/Decks/Deck/index.js
+++ b/src/Decks/Deck/index.js
@@ -5,7 +5,6 @@ import StudyDeck from "./StudyDeck";
 import EditDeck from "./EditDeck";
 import NewCard from "./NewCard";
 import Cards from "./Cards";
-import { readDeck } from "../../utils/api";
 
 function Deck({ decks }) {
   const {
@@ -18,9 +17,11 @@ function Deck({ decks }) {
     decks?.find((deck) => deck.id === Number(deckId))
   );
 
+  //TODO fix the infinite loading bug when user's refresh
+
   useEffect(() => {
     setDeck(decks?.find((deck) => deck.id === Number(deckId)));
-  }, [deckId, deck]);
+  }, [deckId, deck, decks]);
 
   // //Loads the current deck from the API each time deckId changes
   // useEffect(() => {
@@ -34,12 +35,12 @@ function Deck({ decks }) {
   //     });
   // }, [deckId]);
 
-  function setCards(setterFunction) {
-    setDeck((currentDeck) => ({
-      ...currentDeck,
-      cards: setterFunction(currentDeck.cards),
-    }));
-  }
+  // function setCards(setterFunction) {
+  //   setDeck((currentDeck) => ({
+  //     ...currentDeck,
+  //     cards: setterFunction(currentDeck.cards),
+  //   }));
+  // }
 
   return (
     <>
@@ -61,7 +62,7 @@ function Deck({ decks }) {
         </Route>
 
         <Route exact path={path}>
-          <DeckView deck={deck} setCards={setCards} />
+          <DeckView deck={deck} />
         </Route>
 
         <Route>

--- a/src/Decks/Deck/index.js
+++ b/src/Decks/Deck/index.js
@@ -7,25 +7,32 @@ import NewCard from "./NewCard";
 import Cards from "./Cards";
 import { readDeck } from "../../utils/api";
 
-function Deck() {
+function Deck({ decks }) {
   const {
     path, //Current URL Path
     params: { deckId }, //deckId taken from the path
   } = useRouteMatch();
+
   //State variable for the current deck
-  const [deck, setDeck] = useState({});
+  const [deck, setDeck] = useState(
+    decks?.find((deck) => deck.id === Number(deckId))
+  );
 
-  //Loads the current deck from the API each time deckId changes
   useEffect(() => {
-    const controller = new AbortController();
+    setDeck(decks?.find((deck) => deck.id === Number(deckId)));
+  }, [deckId, deck]);
 
-    //API call to {API_BASE_URL}/decks/{deckId}?_embed=cards
-    readDeck(deckId, controller.signal)
-      .then(setDeck)
-      .catch((error) => {
-        if (error.name !== "AbortError") throw error;
-      });
-  }, [deckId]);
+  // //Loads the current deck from the API each time deckId changes
+  // useEffect(() => {
+  //   const controller = new AbortController();
+
+  //   //API call to {API_BASE_URL}/decks/{deckId}?_embed=cards
+  //   readDeck(deckId, controller.signal)
+  //     .then(setDeck)
+  //     .catch((error) => {
+  //       if (error.name !== "AbortError") throw error;
+  //     });
+  // }, [deckId]);
 
   function setCards(setterFunction) {
     setDeck((currentDeck) => ({

--- a/src/Decks/Deck/index.js
+++ b/src/Decks/Deck/index.js
@@ -12,19 +12,13 @@ function Deck({ decks }) {
     params: { deckId }, //deckId taken from the path
   } = useRouteMatch();
 
-  //State variable for the current deck
+  //deck is a state variable that stores the current deck Object
   const [deck, setDeck] = useState({});
 
+  //Update deck whenever there is a change to the deckId in the url, or to the parent component's decks array
   useEffect(() => {
-    setDeck(decks?.find((deck) => deck.id === Number(deckId)));
-  }, [deckId, deck, decks]);
-
-  function setCards(setterFunction) {
-    // setDeck((currentDeck) => ({
-    //   ...currentDeck,
-    //   cards: setterFunction(currentDeck.cards),
-    // }));
-  }
+    setDeck(decks?.find((deck) => deck.id === Number(deckId))); //defines the current deck object based on the deckId param in the url
+  }, [deckId, decks]);
 
   return (
     <>
@@ -46,7 +40,7 @@ function Deck({ decks }) {
         </Route>
 
         <Route exact path={path}>
-          <DeckView deck={deck} setDeck={setDeck} setCards={setCards} />
+          <DeckView deck={deck} setDeck={setDeck} />
         </Route>
 
         <Route>

--- a/src/Decks/Deck/index.js
+++ b/src/Decks/Deck/index.js
@@ -13,34 +13,18 @@ function Deck({ decks }) {
   } = useRouteMatch();
 
   //State variable for the current deck
-  const [deck, setDeck] = useState(
-    decks?.find((deck) => deck.id === Number(deckId))
-  );
-
-  //TODO fix the infinite loading bug when user's refresh
+  const [deck, setDeck] = useState({});
 
   useEffect(() => {
     setDeck(decks?.find((deck) => deck.id === Number(deckId)));
   }, [deckId, deck, decks]);
 
-  // //Loads the current deck from the API each time deckId changes
-  // useEffect(() => {
-  //   const controller = new AbortController();
-
-  //   //API call to {API_BASE_URL}/decks/{deckId}?_embed=cards
-  //   readDeck(deckId, controller.signal)
-  //     .then(setDeck)
-  //     .catch((error) => {
-  //       if (error.name !== "AbortError") throw error;
-  //     });
-  // }, [deckId]);
-
-  // function setCards(setterFunction) {
-  //   setDeck((currentDeck) => ({
-  //     ...currentDeck,
-  //     cards: setterFunction(currentDeck.cards),
-  //   }));
-  // }
+  function setCards(setterFunction) {
+    // setDeck((currentDeck) => ({
+    //   ...currentDeck,
+    //   cards: setterFunction(currentDeck.cards),
+    // }));
+  }
 
   return (
     <>
@@ -62,7 +46,7 @@ function Deck({ decks }) {
         </Route>
 
         <Route exact path={path}>
-          <DeckView deck={deck} />
+          <DeckView deck={deck} setDeck={setDeck} setCards={setCards} />
         </Route>
 
         <Route>

--- a/src/Decks/index.js
+++ b/src/Decks/index.js
@@ -3,7 +3,7 @@ import { Route, Switch, useRouteMatch } from "react-router-dom";
 import Deck from "./Deck";
 import NewDeck from "./NewDeck";
 
-function Decks() {
+function Decks({ decks, setDecks }) {
   const { url } = useRouteMatch();
   return (
     <>
@@ -12,7 +12,7 @@ function Decks() {
           <NewDeck />
         </Route>
         <Route path={`${url}/:deckId`}>
-          <Deck />
+          <Deck decks={decks} />
         </Route>
         <Route>
           <h1>Not a valid URL!</h1>

--- a/src/Decks/index.js
+++ b/src/Decks/index.js
@@ -12,7 +12,7 @@ function Decks({ decks, setDecks }) {
           <NewDeck />
         </Route>
         <Route path={`${url}/:deckId`}>
-          <Deck decks={decks} />
+          <Deck decks={decks} setDecks={setDecks} />
         </Route>
         <Route>
           <h1>Not a valid URL!</h1>

--- a/src/HomePage/DeckList.js
+++ b/src/HomePage/DeckList.js
@@ -1,16 +1,23 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import CreateDeckBtn from "../CommonComponents/Buttons/CreateDeckBtn";
 import LoadingMessage from "../CommonComponents/LoadingMessage";
 import DeckListItem from "./DeckListItem";
 
 function DeckList({ decks, setDecks }) {
-  //map through every deck in decks to create a DeckListItem for each.
-  const deckList = decks.map((deck, key) => (
-    <DeckListItem key={key} deck={deck} setDecks={setDecks} />
-  ));
+  const [deckList, setDeckList] = useState([]);
+
+  useEffect(() => {
+    //map through every deck in decks to create a DeckListItem for each.
+    setDeckList(
+      decks.map((deck, key) => (
+        <DeckListItem key={key} deck={deck} setDecks={setDecks} />
+      ))
+    );
+  }, [decks]);
+
   return deckList?.length ? (
     <>
-      <CreateDeckBtn />
+      <CreateDeckBtn setDecks={setDecks} />
       {deckList}
     </>
   ) : (

--- a/src/HomePage/DeckList.js
+++ b/src/HomePage/DeckList.js
@@ -4,8 +4,10 @@ import LoadingMessage from "../CommonComponents/LoadingMessage";
 import DeckListItem from "./DeckListItem";
 
 function DeckList({ decks, setDecks }) {
+  //useState variable to store an array of DeckListItem components
   const [deckList, setDeckList] = useState([]);
 
+  //Update deckList whenever there is a change to decks or setDecks
   useEffect(() => {
     //map through every deck in decks to create a DeckListItem for each.
     setDeckList(
@@ -13,8 +15,9 @@ function DeckList({ decks, setDecks }) {
         <DeckListItem key={key} deck={deck} setDecks={setDecks} />
       ))
     );
-  }, [decks]);
+  }, [decks, setDecks]);
 
+  //If there is a deckList, and it has a non-zero length, render it, otherwise show LoadingMessage
   return deckList?.length ? (
     <>
       <CreateDeckBtn setDecks={setDecks} />

--- a/src/HomePage/DeckListItem.js
+++ b/src/HomePage/DeckListItem.js
@@ -11,10 +11,14 @@ function DeckListItem({ deck, setDecks }) {
         <p className="card-text">{deck.description}</p>
         <ViewDeckBtn path={`/decks/${deck.id}`} />
         <StudyButton path={`/decks/${deck.id}`} />
-        <DeleteButton objToDelete={deck} objType={"deck"} setDecks={setDecks} />
+        <DeleteButton
+          objToDelete={deck}
+          objType={"deck"}
+          setObjState={setDecks}
+        />
       </div>
     </div>
   );
 }
 
-export default DeckListItem;         
+export default DeckListItem;

--- a/src/HomePage/DeckListItem.js
+++ b/src/HomePage/DeckListItem.js
@@ -3,7 +3,7 @@ import DeleteButton from "../CommonComponents/Buttons/DeleteButton";
 import StudyButton from "../CommonComponents/Buttons/StudyButton";
 import ViewDeckBtn from "../CommonComponents/Buttons/ViewDeckBtn";
 
-function DeckListItem({ deck }) {
+function DeckListItem({ deck, setDecks }) {
   return (
     <div className="card">
       <div className="card-body">
@@ -11,10 +11,10 @@ function DeckListItem({ deck }) {
         <p className="card-text">{deck.description}</p>
         <ViewDeckBtn path={`/decks/${deck.id}`} />
         <StudyButton path={`/decks/${deck.id}`} />
-        <DeleteButton objToDelete={deck} objType={"deck"} />
+        <DeleteButton objToDelete={deck} objType={"deck"} setDecks={setDecks} />
       </div>
     </div>
   );
 }
 
-export default DeckListItem;
+export default DeckListItem;         

--- a/src/HomePage/index.js
+++ b/src/HomePage/index.js
@@ -1,10 +1,7 @@
-import React, { useEffect, useState } from "react";
-import { listDecks } from "../utils/api";
+import React from "react";
 import DeckList from "./DeckList";
 
-function HomePage({decks, setDecks}) {
-
-
+function HomePage({ decks, setDecks }) {
   return <DeckList decks={decks} setDecks={setDecks} />;
 }
 

--- a/src/HomePage/index.js
+++ b/src/HomePage/index.js
@@ -2,21 +2,8 @@ import React, { useEffect, useState } from "react";
 import { listDecks } from "../utils/api";
 import DeckList from "./DeckList";
 
-function HomePage() {
-  //decks is a state variable array of each deck in the API
-  const [decks, setDecks] = useState([]);
+function HomePage({decks, setDecks}) {
 
-  //Loads the list of Decks from the API on startup
-  useEffect(() => {
-    const controller = new AbortController(); //to abort old requests
-
-    //API call to {API_BASE_URL}/decks?_embed=cards (All cards embedded in the deck)
-    listDecks(controller.signal)
-      .then(setDecks)
-      .catch((error) => {
-        if (error.name !== "AbortError") throw error;
-      });
-  }, []);
 
   return <DeckList decks={decks} setDecks={setDecks} />;
 }

--- a/src/Layout/index.js
+++ b/src/Layout/index.js
@@ -1,21 +1,37 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Route, Switch } from "react-router-dom";
 import Header from "./Header";
 import NotFound from "./NotFound";
 import HomePage from "../HomePage";
 import Decks from "../Decks";
+import { listDecks } from "../utils/api";
 
 function Layout() {
+  //decks is a state variable array of each deck in the API
+  const [decks, setDecks] = useState([]);
+
+  //Loads the list of Decks from the API on startup
+  useEffect(() => {
+    const controller = new AbortController(); //to abort old requests
+
+    //API call to {API_BASE_URL}/decks?_embed=cards (All cards embedded in the deck)
+    listDecks(controller.signal)
+      .then(setDecks)
+      .catch((error) => {
+        if (error.name !== "AbortError") throw error;
+      });
+  }, []);
+
   return (
     <>
       <Header />
       <div className="container">
         <Switch>
           <Route exact path="/">
-            <HomePage />
+            <HomePage decks={decks} setDecks={setDecks} />
           </Route>
           <Route path="/decks/">
-            <Decks />
+            <Decks decks={decks} setDecks={setDecks} />
           </Route>
           <NotFound />
         </Switch>


### PR DESCRIPTION
## Updates from this pull request
### Fixed the bug where refreshing broke the app!
Cleaned up the structure of the code again. Rather than making continuous API GET calls all over the place, figured it would be more efficient to just make one GET request on startup only, and pass down all the information to the corresponding components with lifted State Variables, and useEffectHooks to re-render the components whenever they change. The only other GET requests will be made whenever a PUT, ADD, or DELETE request is made. Cleaning up my useEffectHooks also meant fixing the bug, as now the correct components will re-render when they receive their corresponding information.  

### Added DELETE request functionality for both cards and decks
While cleaning up the GET API calls, I also inserted the DELETE API call, since I figured it was really easy to implement, considering the skeleton provided most of the legwork.


### TODO:
- Needs ADD request functionality for deck and card
- Needs PUT request functionality for deck and card
- Need to add cleanup functions to each of the useEffectHooks to prevent data leaks.
- Add personal flair and color scheme to the project and clean up it's style.
- Turn the loading message into a buffing animation.
- Refactor for comments and readability.